### PR TITLE
feat(A-1): stub runners

### DIFF
--- a/docs/reference_machine.yaml
+++ b/docs/reference_machine.yaml
@@ -1,0 +1,41 @@
+# Reference Machine Schema
+# This YAML schema defines the structure for reference machine configurations
+# used in SCU benchmarking and normalization processes.
+
+reference_machine:
+  # CPU architecture (e.g., x86_64, arm64, riscv64)
+  arch: string
+  
+  # CPU model identifier (e.g., "Intel Xeon E5-2686 v4", "AMD EPYC 7742")
+  cpu_model: string
+  
+  # Number of CPU cores
+  cores: integer
+  
+  # Memory in gigabytes
+  mem_gb: integer
+  
+  # Operating system (e.g., "Ubuntu 22.04", "CentOS 8", "Windows Server 2022")
+  os: string
+  
+  # Version information for benchmark suites used
+  benchmark_suite_versions:
+    # MLPerf version (if applicable)
+    mlperf: string
+    # SPEC CPU version (if applicable)  
+    spec_cpu: string
+    # Custom benchmark versions
+    custom: object
+
+# Example configuration:
+# reference_machine:
+#   arch: "x86_64"
+#   cpu_model: "Intel Xeon E5-2686 v4"
+#   cores: 16
+#   mem_gb: 64
+#   os: "Ubuntu 22.04"
+#   benchmark_suite_versions:
+#     mlperf: "v3.1"
+#     spec_cpu: "2017"
+#     custom:
+#       scu_bench: "v1.0"

--- a/runners/README.md
+++ b/runners/README.md
@@ -1,0 +1,74 @@
+# Benchmark Runners
+
+This directory contains standardized benchmark runners for SCU measurement and analysis.
+
+## Available Runners
+
+### MLPerf Runner (`mlperf/runner.py`)
+Dry-run implementation of MLPerf benchmarks with SCU estimation.
+
+**Supported Benchmarks:**
+- ResNet (image classification)
+- BERT (natural language processing)
+- DLRM (recommendation systems)
+- 3D-UNet (medical imaging)
+- RNN-T (speech recognition)
+- RetinaNet, MaskRCNN, SSD (object detection)
+- MiniGo (reinforcement learning)
+
+**Usage:**
+```bash
+# Run single benchmark
+python runners/mlperf/runner.py resnet
+
+# Run benchmark suite
+python runners/mlperf/runner.py suite
+
+# Run with config
+python runners/mlperf/runner.py bert config.json
+```
+
+### STREAM Runner (`stream/runner.py`)
+Memory bandwidth benchmark with SCU correlation.
+
+**Operations:**
+- Copy: `a[i] = b[i]`
+- Scale: `a[i] = q * b[i]`
+- Add: `a[i] = b[i] + c[i]`
+- Triad: `a[i] = b[i] + q * c[i]`
+
+**Usage:**
+```bash
+# Run single operation
+python runners/stream/runner.py copy
+
+# Run full suite
+python runners/stream/runner.py suite
+
+# Custom array size
+python runners/stream/runner.py suite 50000000
+```
+
+## Output Format
+
+Both runners provide structured output with SCU estimates:
+
+```json
+{
+  "benchmark_name": "resnet",
+  "execution_time": 0.105,
+  "throughput": 1250.5,
+  "scu_estimate": 0.131,
+  "metadata": {
+    "mode": "dry-run",
+    "timestamp": 1234567890.0
+  }
+}
+```
+
+## Integration Notes
+
+- All runners are currently in **dry-run mode** for development
+- SCU estimates use placeholder calculations
+- Results include metadata for analysis pipeline integration
+- Runners support JSON configuration for parameterization

--- a/runners/mlperf/runner.py
+++ b/runners/mlperf/runner.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+MLPerf Benchmark Runner (Dry-run stub)
+Provides standardized interface for MLPerf benchmarks with SCU measurement.
+"""
+
+import time
+import json
+import sys
+from typing import Dict, Any, List
+from dataclasses import dataclass
+
+
+@dataclass
+class BenchmarkResult:
+    """Result container for MLPerf benchmark execution."""
+    benchmark_name: str
+    execution_time: float
+    throughput: float
+    accuracy: float
+    scu_estimate: float
+    metadata: Dict[str, Any]
+
+
+class MLPerfRunner:
+    """Dry-run MLPerf benchmark runner for SCU measurement integration."""
+    
+    def __init__(self, config: Dict[str, Any] = None):
+        self.config = config or {}
+        self.supported_benchmarks = [
+            "resnet", "bert", "dlrm", "3d-unet", "rnnt",
+            "retinanet", "maskrcnn", "ssd", "minigo"
+        ]
+    
+    def validate_benchmark(self, benchmark_name: str) -> bool:
+        """Validate if benchmark is supported."""
+        return benchmark_name.lower() in self.supported_benchmarks
+    
+    def run_benchmark(self, benchmark_name: str, **kwargs) -> BenchmarkResult:
+        """Run MLPerf benchmark (dry-run simulation)."""
+        if not self.validate_benchmark(benchmark_name):
+            raise ValueError(f"Unsupported benchmark: {benchmark_name}")
+        
+        print(f"[DRY-RUN] Executing MLPerf {benchmark_name}...")
+        
+        # Simulate benchmark execution
+        start_time = time.time()
+        time.sleep(0.1)  # Simulate execution time
+        execution_time = time.time() - start_time
+        
+        # Generate realistic mock results
+        mock_results = {
+            "resnet": {"throughput": 1250.5, "accuracy": 0.7612},
+            "bert": {"throughput": 890.2, "accuracy": 0.8945},
+            "dlrm": {"throughput": 2340.1, "accuracy": 0.8021},
+        }
+        
+        benchmark_data = mock_results.get(benchmark_name.lower(), 
+                                        {"throughput": 1000.0, "accuracy": 0.85})
+        
+        # Calculate estimated SCU (mock calculation)
+        scu_estimate = (benchmark_data["throughput"] * execution_time) / 1000.0
+        
+        result = BenchmarkResult(
+            benchmark_name=benchmark_name,
+            execution_time=execution_time,
+            throughput=benchmark_data["throughput"],
+            accuracy=benchmark_data["accuracy"],
+            scu_estimate=scu_estimate,
+            metadata={
+                "mode": "dry-run",
+                "config": self.config,
+                "timestamp": time.time()
+            }
+        )
+        
+        print(f"[DRY-RUN] Completed {benchmark_name}: "
+              f"SCU={scu_estimate:.3f}, Throughput={benchmark_data['throughput']}")
+        
+        return result
+    
+    def run_suite(self, benchmarks: List[str] = None) -> List[BenchmarkResult]:
+        """Run multiple MLPerf benchmarks."""
+        if benchmarks is None:
+            benchmarks = self.supported_benchmarks[:3]  # Run first 3 for demo
+        
+        results = []
+        for benchmark in benchmarks:
+            try:
+                result = self.run_benchmark(benchmark)
+                results.append(result)
+            except Exception as e:
+                print(f"Error running {benchmark}: {e}")
+        
+        return results
+
+
+def main():
+    """CLI interface for MLPerf runner."""
+    if len(sys.argv) < 2:
+        print("Usage: python runner.py <benchmark_name> [config.json]")
+        print(f"Supported benchmarks: {MLPerfRunner().supported_benchmarks}")
+        sys.exit(1)
+    
+    benchmark_name = sys.argv[1]
+    config_file = sys.argv[2] if len(sys.argv) > 2 else None
+    
+    config = {}
+    if config_file:
+        with open(config_file, 'r') as f:
+            config = json.load(f)
+    
+    runner = MLPerfRunner(config)
+    
+    if benchmark_name == "suite":
+        results = runner.run_suite()
+        for result in results:
+            print(f"Result: {result}")
+    else:
+        result = runner.run_benchmark(benchmark_name)
+        print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/runners/stream/runner.py
+++ b/runners/stream/runner.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+STREAM Benchmark Runner (Dry-run stub)
+Memory bandwidth measurement with SCU correlation.
+"""
+
+import time
+import sys
+import json
+from typing import Dict, Any, List
+from dataclasses import dataclass
+import psutil
+
+
+@dataclass
+class StreamResult:
+    """Result container for STREAM benchmark execution."""
+    operation: str
+    bandwidth_mb_s: float
+    execution_time: float
+    array_size: int
+    scu_estimate: float
+    metadata: Dict[str, Any]
+
+
+class StreamRunner:
+    """Dry-run STREAM benchmark runner for memory bandwidth measurement."""
+    
+    def __init__(self, config: Dict[str, Any] = None):
+        self.config = config or {}
+        self.operations = ["copy", "scale", "add", "triad"]
+        self.default_array_size = self.config.get("array_size", 10000000)
+    
+    def get_system_info(self) -> Dict[str, Any]:
+        """Gather system memory information."""
+        memory = psutil.virtual_memory()
+        return {
+            "total_memory_gb": memory.total / (1024**3),
+            "available_memory_gb": memory.available / (1024**3),
+            "cpu_count": psutil.cpu_count(),
+            "cpu_freq_mhz": psutil.cpu_freq().current if psutil.cpu_freq() else None
+        }
+    
+    def run_operation(self, operation: str, array_size: int = None) -> StreamResult:
+        """Run specific STREAM operation (dry-run simulation)."""
+        if operation not in self.operations:
+            raise ValueError(f"Unsupported operation: {operation}")
+        
+        array_size = array_size or self.default_array_size
+        
+        print(f"[DRY-RUN] Running STREAM {operation} with array size {array_size}")
+        
+        # Simulate operation execution
+        start_time = time.time()
+        time.sleep(0.05)  # Simulate execution time
+        execution_time = time.time() - start_time
+        
+        # Mock bandwidth calculations based on operation type
+        base_bandwidths = {
+            "copy": 25000.0,    # MB/s
+            "scale": 23000.0,
+            "add": 21000.0,
+            "triad": 20000.0
+        }
+        
+        # Add some realistic variation
+        bandwidth = base_bandwidths[operation] * (0.9 + (hash(str(time.time())) % 200) / 1000)
+        
+        # Calculate memory footprint in bytes
+        element_size = 8  # 8 bytes for double precision
+        memory_footprint = array_size * element_size
+        
+        # Estimate SCU based on memory bandwidth and computation
+        operations_per_element = {"copy": 2, "scale": 2, "add": 3, "triad": 3}
+        total_operations = array_size * operations_per_element[operation]
+        scu_estimate = (total_operations / 1e9) * execution_time  # Rough GFLOP-seconds
+        
+        result = StreamResult(
+            operation=operation,
+            bandwidth_mb_s=bandwidth,
+            execution_time=execution_time,
+            array_size=array_size,
+            scu_estimate=scu_estimate,
+            metadata={
+                "mode": "dry-run",
+                "memory_footprint_mb": memory_footprint / (1024**2),
+                "system_info": self.get_system_info(),
+                "timestamp": time.time()
+            }
+        )
+        
+        print(f"[DRY-RUN] {operation}: {bandwidth:.1f} MB/s, SCU={scu_estimate:.6f}")
+        
+        return result
+    
+    def run_full_suite(self, array_size: int = None) -> List[StreamResult]:
+        """Run all STREAM operations."""
+        array_size = array_size or self.default_array_size
+        
+        print(f"[DRY-RUN] Running full STREAM suite with array size {array_size}")
+        
+        results = []
+        for operation in self.operations:
+            try:
+                result = self.run_operation(operation, array_size)
+                results.append(result)
+            except Exception as e:
+                print(f"Error running {operation}: {e}")
+        
+        return results
+    
+    def generate_report(self, results: List[StreamResult]) -> Dict[str, Any]:
+        """Generate summary report from STREAM results."""
+        if not results:
+            return {"error": "No results to report"}
+        
+        bandwidths = [r.bandwidth_mb_s for r in results]
+        total_scu = sum(r.scu_estimate for r in results)
+        
+        return {
+            "summary": {
+                "operations_run": len(results),
+                "max_bandwidth_mb_s": max(bandwidths),
+                "min_bandwidth_mb_s": min(bandwidths),
+                "avg_bandwidth_mb_s": sum(bandwidths) / len(bandwidths),
+                "total_scu_estimate": total_scu
+            },
+            "results": [
+                {
+                    "operation": r.operation,
+                    "bandwidth_mb_s": r.bandwidth_mb_s,
+                    "scu_estimate": r.scu_estimate
+                } for r in results
+            ],
+            "system_info": results[0].metadata["system_info"]
+        }
+
+
+def main():
+    """CLI interface for STREAM runner."""
+    if len(sys.argv) < 2:
+        print("Usage: python runner.py <operation|suite> [array_size] [config.json]")
+        print(f"Operations: {StreamRunner().operations}")
+        print("Use 'suite' to run all operations")
+        sys.exit(1)
+    
+    command = sys.argv[1]
+    array_size = int(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2].isdigit() else None
+    config_file = sys.argv[3] if len(sys.argv) > 3 else None
+    
+    config = {}
+    if config_file:
+        with open(config_file, 'r') as f:
+            config = json.load(f)
+    
+    runner = StreamRunner(config)
+    
+    if command == "suite":
+        results = runner.run_full_suite(array_size)
+        report = runner.generate_report(results)
+        print("\n=== STREAM Benchmark Report ===")
+        print(json.dumps(report, indent=2))
+    else:
+        result = runner.run_operation(command, array_size)
+        print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add dry-run MLPerf and STREAM benchmark runners with SCU estimation.

## Summary
- MLPerf runner supports 9 benchmark types with mock results
- STREAM runner implements 4 memory bandwidth operations  
- Both runners provide structured output with SCU estimates
- Includes comprehensive README with usage examples

## Test plan
- [x] Verify MLPerf runner executes all supported benchmarks
- [x] Verify STREAM runner executes all memory operations
- [x] Confirm structured output format with SCU estimates
- [x] Test CLI interfaces for both runners

🤖 Generated with [Claude Code](https://claude.ai/code)